### PR TITLE
Add opti_screener option analytics CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,113 @@
-# options
+# opti_screener
+
+`opti_screener` is a Python 3.11 CLI that surfaces long-premium option ideas that look "cheap to buy" based on implied volatility, liquidity and theoretical edge metrics. It integrates Polygon.io (primary) and Tradier (fallback) market data feeds, computes historical volatility analytics, and ranks contracts with a transparent scoring model.
+
+## Features
+
+- Adapter-based data providers with automatic fallback between Polygon.io and Tradier.
+- Computes HV20/HV60, IV percentile & rank, IV/HV ratios, expected move via ATM straddles and breakeven gaps.
+- Configurable filters for DTE, delta, spreads, open interest, premium caps and strategy (calls/puts/both).
+- Weighted scoring model covering liquidity, IV cheapness, theoretical edge and expected-move alignment.
+- Outputs both a Rich-powered console table and a full CSV file with companion metadata JSON.
+- Optional YAML configuration files and ticker lists.
+
+## Project Structure
+
+```
+opti_screener/
+  __init__.py
+  analytics.py
+  cli.py
+  models.py
+  ranking.py
+  utils.py
+  data_providers/
+    __init__.py
+    base.py
+    polygon.py
+    tradier.py
+requirements.txt
+README.md
+tests/
+```
+
+## Getting Started
+
+### 1. Clone and install dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### 2. Environment variables
+
+Create a `.env` file (or export in your shell) containing the vendor API keys:
+
+```
+POLYGON_API_KEY=your_polygon_api_key
+TRADIER_API_KEY=your_tradier_api_key
+```
+
+### 3. Example usage
+
+```bash
+opti-screener \
+  --tickers "AAPL,MSFT,AMD" \
+  --provider polygon \
+  --asof "2025-09-29" \
+  --min-dte 30 --max-dte 90 \
+  --min-delta 0.25 --max-delta 0.40 \
+  --max-spread-pct 0.10 \
+  --min-oi 300 \
+  --max-premium 150 \
+  --output results.csv \
+  --weights "w1=1,w2=0.5,w3=0.5,w4=1,w5=1,w6=1,w7=1"
+```
+
+Additional options:
+
+- `--tickers-file`: provide a CSV/TXT file with comma or newline separated tickers.
+- `--config config.yaml`: use a YAML config to override CLI defaults.
+- `--strategy`: choose `calls`, `puts`, or `both` (default).
+
+### 4. Output
+
+- `results.csv`: full dataset of ranked option contracts.
+- `results.csv.meta.json`: metadata including timestamp, tickers, weights, filters and provider used.
+- Console table: top 15 ranked contracts with key metrics and total score.
+
+## Testing
+
+```bash
+pytest
+```
+
+## Scoring Model Overview
+
+```
+LiquidityScore  = w1*(1 - SpreadPctNorm) + w2*OI_z + w3*Vol_z
+IVCheapScore    = w4*(1 - IVPercentile) + w5*(1 - IV_to_HV)
+EdgeScore       = w6*((Theo - Mid)/Mid)
+EMScore         = w7*((EM_$ - BreakevenGap_$)/EM_$)
+TotalScore      = LiquidityScore + IVCheapScore + EdgeScore + EMScore
+```
+
+Weights are tunable with the `--weights` flag or YAML configuration.
+
+## FAQ
+
+**Why does IV often exceed HV?**
+: Implied volatility embeds market expectations of future variance plus risk premium, so it typically prices higher than realized volatility.
+
+**What if a provider lacks theoretical prices?**
+: The screener treats missing theo data as zero edge. You can prioritise liquidity or IV cheapness through weights.
+
+**How do I interpret breakeven vs expected move?**
+: A positive EM score indicates the breakeven point lies inside the expected move, suggesting a favourable probability of profit if the move materialises.
+
+## License
+
+This project is provided as-is without warranty. Consult your broker's API terms before use.

--- a/opti_screener/__init__.py
+++ b/opti_screener/__init__.py
@@ -1,0 +1,7 @@
+"""Top-level package for opti_screener."""
+
+from .cli import app
+
+__all__ = ["app"]
+
+__version__ = "0.1.0"

--- a/opti_screener/analytics.py
+++ b/opti_screener/analytics.py
@@ -1,0 +1,274 @@
+"""Analytical routines for option screening."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+from .models import OptionContract, OptionType
+from .utils import safe_div
+
+TRADING_DAYS_PER_YEAR = 252
+
+
+@dataclass(slots=True)
+class ContractAnalytics:
+    """Holds derived analytics for a single option contract."""
+
+    contract: OptionContract
+    dte: int
+    spread: float | None
+    spread_pct: float | None
+    iv_percentile: float | None
+    iv_rank: float | None
+    hv20: float | None
+    hv60: float | None
+    iv_to_hv: float | None
+    expected_move_dollar: float | None
+    expected_move_pct: float | None
+    breakeven_price: float | None
+    breakeven_gap_dollar: float | None
+    breakeven_gap_pct: float | None
+    breakeven_vs_em_pct: float | None
+    theo_edge_pct: float | None
+
+
+def compute_historical_volatility(close_series: pd.Series, window: int) -> float | None:
+    """Return annualised historical volatility over *window* trading days."""
+
+    close_series = close_series.dropna()
+    if len(close_series) <= 1:
+        return None
+    returns = close_series.pct_change().dropna()
+    if returns.empty:
+        return None
+    windowed = returns.iloc[-window:]
+    if len(windowed) <= 1:
+        return None
+    hv = np.sqrt(TRADING_DAYS_PER_YEAR) * windowed.std(ddof=1)
+    return float(hv)
+
+
+def compute_iv_percentile(iv_history: pd.Series | None, current_iv: float | None) -> tuple[float, float]:
+    """Return IV percentile and IV rank for the current IV value."""
+
+    if iv_history is None or current_iv is None:
+        return (np.nan, np.nan)
+    history = iv_history.dropna()
+    if history.empty:
+        return (np.nan, np.nan)
+    percentile = float((history <= current_iv).mean())
+    min_iv = float(history.min())
+    max_iv = float(history.max())
+    if max_iv == min_iv:
+        iv_rank = 0.5
+    else:
+        iv_rank = float((current_iv - min_iv) / (max_iv - min_iv))
+    return (percentile, iv_rank)
+
+
+def expected_move_from_straddle(contracts: Iterable[OptionContract], spot: float | None) -> dict[datetime, tuple[float | None, float | None]]:
+    """Compute expected move per expiry based on ATM straddle mid prices."""
+
+    if spot is None:
+        return {}
+    grouped: dict[tuple[datetime, float], dict[OptionType, OptionContract]] = {}
+    for contract in contracts:
+        if contract.mid is None:
+            continue
+        key = (contract.expiry, contract.strike)
+        grouped.setdefault(key, {})[contract.option_type] = contract
+    exp_to_candidates: defaultdict[datetime, list[tuple[float, float, float | None]]] = defaultdict(list)
+    for (expiry, strike), pair in grouped.items():
+        call = pair.get(OptionType.CALL)
+        put = pair.get(OptionType.PUT)
+        if not call or not put:
+            continue
+        call_mid = call.mid
+        put_mid = put.mid
+        if call_mid is None or put_mid is None:
+            continue
+        distance = abs(strike - spot)
+        em_dollar = float(call_mid + put_mid)
+        em_pct = safe_div(em_dollar, spot)
+        exp_to_candidates[expiry].append((distance, em_dollar, float(em_pct) if em_pct is not None else None))
+    result: dict[datetime, tuple[float | None, float | None]] = {}
+    for expiry, candidates in exp_to_candidates.items():
+        if not candidates:
+            continue
+        _, em_dollar, em_pct = min(candidates, key=lambda item: item[0])
+        result[expiry] = (em_dollar, em_pct)
+    return result
+
+
+def breakeven_price(contract: OptionContract) -> float | None:
+    """Return the breakeven price for the contract based on mid premium."""
+
+    premium = contract.premium
+    if premium is None:
+        return None
+    if contract.option_type is OptionType.CALL:
+        return float(contract.strike + premium)
+    return float(contract.strike - premium)
+
+
+def breakeven_gap(contract: OptionContract, breakeven: float | None) -> tuple[float | None, float | None]:
+    """Return the dollar and percent gap between spot and breakeven."""
+
+    if breakeven is None or contract.underlying_price is None:
+        return (None, None)
+    spot = float(contract.underlying_price)
+    gap_dollar = abs(breakeven - spot)
+    gap_pct = safe_div(gap_dollar, spot)
+    return (float(gap_dollar), float(gap_pct) if gap_pct is not None else None)
+
+
+def _contract_key(contract: OptionContract) -> str:
+    return f"{contract.ticker}-{contract.expiry.isoformat()}-{contract.option_type.value}-{contract.strike:.2f}"
+
+
+def compute_contract_rows(
+    contracts: list[OptionContract],
+    hv20: float | None,
+    hv60: float | None,
+    iv_history: pd.Series | None,
+    asof: datetime,
+    expected_moves: dict[datetime, tuple[float | None, float | None]],
+    theo_prices: dict[str, float | None],
+) -> pd.DataFrame:
+    """Return a dataframe containing analytics per contract."""
+
+    rows: list[dict[str, object]] = []
+    for contract in contracts:
+        spot = contract.underlying_price
+        current_iv = contract.mark_iv
+        iv_percentile, iv_rank = compute_iv_percentile(iv_history, current_iv)
+        iv_to_hv = None
+        if hv20 is not None and current_iv is not None:
+            hv_base = max(hv20, 1e-6)
+            iv_to_hv = float(current_iv / hv_base)
+        em_dollar, em_pct = expected_moves.get(contract.expiry, (None, None))
+        be_price = breakeven_price(contract)
+        gap_dollar, gap_pct = breakeven_gap(contract, be_price)
+        be_vs_em_pct = None
+        if gap_dollar is not None and em_dollar not in (None, 0):
+            be_vs_em_pct = float(gap_dollar / em_dollar)
+        theo_price = theo_prices.get(_contract_key(contract))
+        theo_edge_pct = None
+        if theo_price is not None and contract.mid not in (None, 0):
+            theo_edge_pct = float((theo_price - contract.mid) / contract.mid)
+        spread = None
+        spread_pct = None
+        if contract.ask is not None and contract.bid is not None:
+            spread = float(contract.ask - contract.bid)
+            if contract.mid not in (None, 0):
+                spread_pct = float(spread / contract.mid)
+        dte = (contract.expiry.date() - asof.date()).days
+        rows.append(
+            {
+                "ticker": contract.ticker,
+                "expiry": contract.expiry,
+                "dte": dte,
+                "type": contract.option_type.value,
+                "strike": contract.strike,
+                "bid": contract.bid,
+                "ask": contract.ask,
+                "mid": contract.mid,
+                "mark_iv": current_iv,
+                "delta": contract.delta,
+                "gamma": contract.gamma,
+                "vega": contract.vega,
+                "theta": contract.theta,
+                "volume": contract.volume,
+                "open_interest": contract.open_interest,
+                "spot": spot,
+                "spread": spread,
+                "spread_pct": spread_pct,
+                "iv_percentile": iv_percentile,
+                "iv_rank": iv_rank,
+                "hv20": hv20,
+                "hv60": hv60,
+                "iv_to_hv": iv_to_hv,
+                "expected_move_dollar": em_dollar,
+                "expected_move_pct": em_pct,
+                "breakeven_price": be_price,
+                "breakeven_gap_dollar": gap_dollar,
+                "breakeven_gap_pct": gap_pct,
+                "breakeven_vs_em_pct": be_vs_em_pct,
+                "theo_edge_pct": theo_edge_pct,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def normalize_liquidity(df: pd.DataFrame) -> pd.DataFrame:
+    """Add normalized liquidity metrics to the dataframe."""
+
+    df = df.copy()
+    if "spread_pct" in df.columns:
+        df["spread_score_component"] = 1 - df["spread_pct"].clip(lower=0, upper=0.20) / 0.20
+    else:
+        df["spread_score_component"] = 0.0
+    for column, score_column in (("open_interest", "oi_z"), ("volume", "volume_z")):
+        if column not in df.columns:
+            df[score_column] = np.nan
+            continue
+        values = pd.to_numeric(df[column], errors="coerce")
+        std = float(values.std(ddof=0)) if values.notna().any() else 0.0
+        if std == 0:
+            df[score_column] = np.where(values.notna(), 0.0, np.nan)
+        else:
+            df[score_column] = (values - values.mean()) / std
+    return df
+
+
+def apply_scoring(df: pd.DataFrame, weights: dict[str, float]) -> pd.DataFrame:
+    """Compute weighted scores for each contract."""
+
+    df = normalize_liquidity(df)
+    w1 = weights.get("w1", 1.0)
+    w2 = weights.get("w2", 0.5)
+    w3 = weights.get("w3", 0.5)
+    w4 = weights.get("w4", 1.0)
+    w5 = weights.get("w5", 1.0)
+    w6 = weights.get("w6", 1.0)
+    w7 = weights.get("w7", 1.0)
+
+    df["LiquidityScore"] = (
+        w1 * df["spread_score_component"].fillna(0)
+        + w2 * df["oi_z"].fillna(0)
+        + w3 * df["volume_z"].fillna(0)
+    )
+    df["IVCheapScore"] = (
+        w4 * (1 - df["iv_percentile"].fillna(1.0))
+        + w5 * (1 - df["iv_to_hv"].fillna(1.0))
+    )
+    df["EdgeScore"] = w6 * df["theo_edge_pct"].fillna(0)
+
+    def _em_component(row: pd.Series) -> float:
+        em = row.get("expected_move_dollar")
+        gap = row.get("breakeven_gap_dollar")
+        if em in (None, 0) or gap is None:
+            return 0.0
+        return float(np.clip((em - gap) / em, 0, 1))
+
+    df["EMScore"] = w7 * df.apply(_em_component, axis=1)
+    df["TotalScore"] = df[["LiquidityScore", "IVCheapScore", "EdgeScore", "EMScore"]].sum(axis=1)
+    return df
+
+
+__all__ = [
+    "ContractAnalytics",
+    "apply_scoring",
+    "breakeven_gap",
+    "breakeven_price",
+    "compute_contract_rows",
+    "compute_historical_volatility",
+    "compute_iv_percentile",
+    "expected_move_from_straddle",
+]

--- a/opti_screener/cli.py
+++ b/opti_screener/cli.py
@@ -1,0 +1,327 @@
+"""Command line interface for the opti_screener application."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from .analytics import (
+    compute_contract_rows,
+    compute_historical_volatility,
+    expected_move_from_straddle,
+)
+from .data_providers import PROVIDERS, BaseProvider, get_provider
+from .ranking import DEFAULT_WEIGHTS, FilterConfig, apply_filters, rank_contracts
+from .utils import LOGGER, parse_list, parse_weights, setup_logging, write_metadata
+
+app = typer.Typer(help="Screen for inexpensive long-premium option candidates.")
+console = Console()
+
+
+def _load_yaml_config(path: Path | None) -> dict[str, object]:
+    if not path:
+        return {}
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("pyyaml is required for --config support") from exc
+    with path.open("r", encoding="utf-8") as file:
+        data = yaml.safe_load(file) or {}
+    if not isinstance(data, dict):
+        raise ValueError("Config file must contain a mapping of options")
+    return data
+
+
+def _load_tickers(tickers: str | None, tickers_file: Path | None) -> list[str]:
+    items = set(parse_list(tickers))
+    if tickers_file:
+        file_content = tickers_file.read_text(encoding="utf-8")
+        items.update(parse_list(file_content))
+    if not items:
+        raise typer.BadParameter("At least one ticker is required")
+    return sorted(items)
+
+
+def _instantiate_provider(name: str) -> BaseProvider:
+    try:
+        return get_provider(name)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise typer.BadParameter(str(exc))
+
+
+def _fallback_providers(primary: str) -> list[str]:
+    providers = list(PROVIDERS)
+    normalized = primary.lower()
+    if normalized not in providers:
+        raise typer.BadParameter(f"Unknown provider {primary!r}")
+    providers.remove(normalized)
+    return [normalized, *providers]
+
+
+def _format_date(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value)
+
+
+@app.command()
+def run(
+    tickers: str = typer.Option(..., help="Comma separated tickers."),
+    provider: str = typer.Option("polygon", help="Primary data provider to use."),
+    asof: str | None = typer.Option(None, help="Market date (YYYY-MM-DD)."),
+    min_dte: int = typer.Option(30, help="Minimum days to expiry."),
+    max_dte: int = typer.Option(90, help="Maximum days to expiry."),
+    min_delta: float = typer.Option(0.25, help="Minimum delta for calls."),
+    max_delta: float = typer.Option(0.40, help="Maximum delta for calls."),
+    min_put_delta: float = typer.Option(-0.40, help="Minimum delta for puts."),
+    max_put_delta: float = typer.Option(-0.25, help="Maximum delta for puts."),
+    max_spread_pct: float = typer.Option(0.10, help="Maximum bid/ask spread percentage."),
+    min_oi: int = typer.Option(300, help="Minimum open interest."),
+    min_volume: int = typer.Option(1, help="Minimum same-day volume."),
+    max_premium: float | None = typer.Option(None, help="Maximum option premium."),
+    strategy: str = typer.Option("both", help="Limit to calls, puts, or both."),
+    weights: str | None = typer.Option(None, help="Override scoring weights (e.g. w1=1,w2=0.5)."),
+    output: Path = typer.Option(Path("results.csv"), help="CSV output path."),
+    verbose: bool = typer.Option(False, help="Enable debug logging."),
+    tickers_file: Path | None = typer.Option(None, help="Optional file with tickers."),
+    config: Path | None = typer.Option(None, help="YAML config file overriding defaults."),
+) -> None:
+    """Run the option screener for the specified tickers."""
+
+    setup_logging(verbose=verbose)
+    config_overrides = _load_yaml_config(config)
+
+    tickers = config_overrides.get("tickers", tickers)  # type: ignore[assignment]
+    tickers_file = config_overrides.get("tickers_file", tickers_file)  # type: ignore[assignment]
+    provider = config_overrides.get("provider", provider)  # type: ignore[assignment]
+    asof = config_overrides.get("asof", asof)  # type: ignore[assignment]
+    weights = config_overrides.get("weights", weights)  # type: ignore[assignment]
+    max_premium = config_overrides.get("max_premium", max_premium)  # type: ignore[assignment]
+
+    ticker_list = _load_tickers(tickers, Path(tickers_file) if tickers_file else None)
+    weights_dict = parse_weights(weights, DEFAULT_WEIGHTS)
+    asof_dt = _format_date(asof) or datetime.utcnow()
+
+    filter_config = FilterConfig(
+        min_dte=config_overrides.get("min_dte", min_dte),
+        max_dte=config_overrides.get("max_dte", max_dte),
+        min_delta=config_overrides.get("min_delta", min_delta),
+        max_delta=config_overrides.get("max_delta", max_delta),
+        min_put_delta=config_overrides.get("min_put_delta", min_put_delta),
+        max_put_delta=config_overrides.get("max_put_delta", max_put_delta),
+        max_spread_pct=config_overrides.get("max_spread_pct", max_spread_pct),
+        min_oi=config_overrides.get("min_oi", min_oi),
+        min_volume=config_overrides.get("min_volume", min_volume),
+        max_premium=config_overrides.get("max_premium", max_premium),
+        strategy=config_overrides.get("strategy", strategy),
+    )
+
+    provider_sequence = _fallback_providers(provider)
+
+    frames: list[pd.DataFrame] = []
+    used_provider = provider_sequence[0]
+
+    for ticker in ticker_list:
+        contract_frame = None
+        for provider_name in provider_sequence:
+            try:
+                provider_instance = _instantiate_provider(provider_name)
+                frame = _process_ticker(
+                    provider_instance,
+                    ticker,
+                    asof_dt,
+                    filter_config,
+                )
+                if frame is not None and not frame.empty:
+                    contract_frame = frame
+                    used_provider = provider_name
+                    break
+            except Exception as exc:
+                LOGGER.error("Provider %s failed for %s: %s", provider_name, ticker, exc)
+                continue
+        if contract_frame is None or contract_frame.empty:
+            LOGGER.warning("No contracts returned for %s", ticker)
+            continue
+        frames.append(contract_frame)
+
+    if not frames:
+        raise typer.Exit(code=1)
+
+    combined = pd.concat(frames, ignore_index=True)
+    filtered = apply_filters(combined, filter_config)
+    if filtered.empty:
+        LOGGER.warning("No contracts passed the filter criteria.")
+        raise typer.Exit(code=1)
+
+    ranked = rank_contracts(filtered, weights_dict)
+    write_outputs(ranked, output, ticker_list, weights_dict, filter_config, used_provider, asof_dt)
+    display_table(ranked)
+
+
+def _process_ticker(
+    provider: BaseProvider,
+    ticker: str,
+    asof: datetime,
+    filter_config: FilterConfig,
+) -> pd.DataFrame | None:
+    lookback = max(filter_config.max_dte + 60, 252)
+    chain = provider.get_chain(ticker, asof=asof)
+    if not chain:
+        LOGGER.warning("%s returned empty chain", provider.name)
+        return None
+    ohlc = provider.get_underlying_ohlc(ticker, lookback)
+    hv20 = compute_historical_volatility(ohlc.get("close", pd.Series(dtype=float)), 20)
+    hv60 = compute_historical_volatility(ohlc.get("close", pd.Series(dtype=float)), 60)
+    iv_history = provider.get_iv_history(ticker, 252)
+
+    spot = None
+    if not chain[0].underlying_price and not ohlc.empty:
+        spot = float(ohlc["close"].iloc[-1])
+    for contract in chain:
+        if contract.underlying_price is None and spot is not None:
+            contract.provider_payload.setdefault("underlying_asset", {})
+            contract.underlying_price = spot
+    if spot is None:
+        spot = chain[0].underlying_price
+
+    expected_moves = expected_move_from_straddle(chain, spot)
+    theo_prices = {
+        f"{contract.ticker}-{contract.expiry.isoformat()}-{contract.option_type.value}-{contract.strike:.2f}": provider.get_theo_price(contract)
+        for contract in chain
+    }
+    frame = compute_contract_rows(
+        contracts=chain,
+        hv20=hv20,
+        hv60=hv60,
+        iv_history=iv_history,
+        asof=asof,
+        expected_moves=expected_moves,
+        theo_prices=theo_prices,
+    )
+    return frame
+
+
+def write_outputs(
+    ranked: pd.DataFrame,
+    output: Path,
+    tickers: Iterable[str],
+    weights: dict[str, float],
+    filters: FilterConfig,
+    provider: str,
+    asof: datetime,
+) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    ranked.to_csv(output, index=False)
+    metadata = {
+        "tickers": list(tickers),
+        "weights": weights,
+        "filters": filters.__dict__,
+        "provider": provider,
+        "timestamp": datetime.utcnow().isoformat(),
+        "asof": asof.isoformat(),
+    }
+    write_metadata(output, metadata)
+    console.print(f"Saved results to {output}")
+
+
+def display_table(df: pd.DataFrame, limit: int = 15) -> None:
+    table = Table(show_lines=False)
+    columns = [
+        "ticker",
+        "expiry",
+        "dte",
+        "type",
+        "strike",
+        "delta",
+        "mid",
+        "spread_pct",
+        "open_interest",
+        "volume",
+        "mark_iv",
+        "iv_percentile",
+        "hv20",
+        "iv_to_hv",
+        "expected_move_pct",
+        "breakeven_vs_em_pct",
+        "theo_edge_pct",
+        "TotalScore",
+    ]
+    headers = {
+        "ticker": "Ticker",
+        "expiry": "Expiry",
+        "dte": "DTE",
+        "type": "Type",
+        "strike": "Strike",
+        "delta": "Delta",
+        "mid": "Mid",
+        "spread_pct": "Bid-Ask%",
+        "open_interest": "OI",
+        "volume": "Vol",
+        "mark_iv": "IV30",
+        "iv_percentile": "IVP",
+        "hv20": "HV20",
+        "iv_to_hv": "IV/HV",
+        "expected_move_pct": "EM%",
+        "breakeven_vs_em_pct": "Breakeven% vs EM",
+        "theo_edge_pct": "TheoEdge%",
+        "TotalScore": "TotalScore",
+    }
+    for column in columns:
+        table.add_column(headers[column])
+    subset = df.head(limit)
+    for _, row in subset.iterrows():
+        table.add_row(
+            str(row.get("ticker")),
+            row.get("expiry").strftime("%Y-%m-%d") if isinstance(row.get("expiry"), datetime) else str(row.get("expiry")),
+            f"{row.get('dte')}",
+            str(row.get("type")),
+            f"{row.get('strike'):.2f}" if pd.notna(row.get("strike")) else "",
+            _format_float(row.get("delta")),
+            _format_float(row.get("mid")),
+            _format_percent(row.get("spread_pct")),
+            _format_int(row.get("open_interest")),
+            _format_int(row.get("volume")),
+            _format_percent(row.get("mark_iv")),
+            _format_percent(row.get("iv_percentile")),
+            _format_percent(row.get("hv20")),
+            _format_ratio(row.get("iv_to_hv")),
+            _format_percent(row.get("expected_move_pct")),
+            _format_percent(row.get("breakeven_vs_em_pct")),
+            _format_percent(row.get("theo_edge_pct")),
+            _format_float(row.get("TotalScore")),
+        )
+    console.print(table)
+
+
+def _format_float(value: float | None) -> str:
+    if value is None or pd.isna(value):
+        return ""
+    return f"{value:.2f}"
+
+
+def _format_int(value: float | None) -> str:
+    if value is None or pd.isna(value):
+        return ""
+    return f"{int(value):,}"
+
+
+def _format_percent(value: float | None) -> str:
+    if value is None or pd.isna(value):
+        return ""
+    return f"{value * 100:.1f}%" if abs(value) < 5 else f"{value:.2f}"
+
+
+def _format_ratio(value: float | None) -> str:
+    if value is None or pd.isna(value):
+        return ""
+    return f"{value:.2f}"
+
+
+__all__ = ["app"]

--- a/opti_screener/data_providers/__init__.py
+++ b/opti_screener/data_providers/__init__.py
@@ -1,0 +1,26 @@
+"""Data provider factory."""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .base import BaseProvider
+from .polygon import PolygonProvider
+from .tradier import TradierProvider
+
+PROVIDERS: Dict[str, Type[BaseProvider]] = {
+    PolygonProvider.name: PolygonProvider,
+    TradierProvider.name: TradierProvider,
+}
+
+
+def get_provider(name: str) -> BaseProvider:
+    """Instantiate a provider by name."""
+
+    normalized = name.lower()
+    if normalized not in PROVIDERS:
+        raise KeyError(f"Unknown provider {name!r}")
+    return PROVIDERS[normalized]()
+
+
+__all__ = ["BaseProvider", "PolygonProvider", "TradierProvider", "get_provider", "PROVIDERS"]

--- a/opti_screener/data_providers/base.py
+++ b/opti_screener/data_providers/base.py
@@ -1,0 +1,38 @@
+"""Base data provider abstraction."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import List
+
+import pandas as pd
+
+from ..models import OptionContract
+
+
+class BaseProvider(ABC):
+    """Abstract interface for option data providers."""
+
+    name: str = "base"
+
+    @abstractmethod
+    def get_chain(
+        self, ticker: str, asof: datetime | None = None, max_contracts: int | None = None
+    ) -> List[OptionContract]:
+        """Return a list of :class:`OptionContract` for the given ticker."""
+
+    @abstractmethod
+    def get_underlying_ohlc(self, ticker: str, lookback_days: int) -> pd.DataFrame:
+        """Return a OHLC dataframe indexed by datetime."""
+
+    @abstractmethod
+    def get_iv_history(self, ticker: str, lookback_days: int) -> pd.Series | None:
+        """Return a series of IV30 values or ``None`` if unavailable."""
+
+    @abstractmethod
+    def get_theo_price(self, option: OptionContract) -> float | None:
+        """Return the theoretical price for the contract or ``None``."""
+
+
+__all__ = ["BaseProvider"]

--- a/opti_screener/data_providers/polygon.py
+++ b/opti_screener/data_providers/polygon.py
@@ -1,0 +1,173 @@
+"""Polygon.io data provider implementation."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta
+from typing import Any
+
+import pandas as pd
+import requests
+
+from ..models import OptionContract, OptionType
+from ..utils import LOGGER, require_env
+from .base import BaseProvider
+
+
+class PolygonProvider(BaseProvider):
+    """Fetch data from the Polygon.io REST API."""
+
+    name = "polygon"
+    BASE_URL = "https://api.polygon.io"
+
+    def __init__(self, session: requests.Session | None = None) -> None:
+        self.api_key = require_env("POLYGON_API_KEY")
+        self.session = session or requests.Session()
+
+    # ------------------------------------------------------------------
+    # HTTP helpers
+    # ------------------------------------------------------------------
+    def _request(self, method: str, path: str, params: dict[str, Any] | None = None) -> Any:
+        url = f"{self.BASE_URL}{path}"
+        params = params.copy() if params else {}
+        params.setdefault("apiKey", self.api_key)
+        backoff = 1.0
+        for attempt in range(5):
+            response = self.session.request(method, url, params=params, timeout=30)
+            if response.status_code == 200:
+                return response.json()
+            if response.status_code in {429, 500, 502, 503, 504}:
+                LOGGER.warning(
+                    "Polygon request %s failed with status %s; retrying in %.1fs",
+                    path,
+                    response.status_code,
+                    backoff,
+                )
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            try:
+                payload = response.json()
+            except Exception:  # pragma: no cover - defensive
+                response.raise_for_status()
+            message = payload.get("error") or payload.get("message") or str(payload)
+            raise RuntimeError(f"Polygon API error ({response.status_code}): {message}")
+        raise RuntimeError(f"Polygon API request {path} failed after retries")
+
+    # ------------------------------------------------------------------
+    # API surface
+    # ------------------------------------------------------------------
+    def get_chain(
+        self, ticker: str, asof: datetime | None = None, max_contracts: int | None = None
+    ) -> list[OptionContract]:
+        params = {"underlying_ticker": ticker.upper()}
+        if asof is not None:
+            params["as_of"] = asof.strftime("%Y-%m-%d")
+        data = self._request("GET", "/v3/snapshot/options", params=params)
+        results = data.get("results", [])
+        contracts: list[OptionContract] = []
+        for item in results:
+            option_data = item.get("details", {})
+            greeks = item.get("greeks", {})
+            quote = item.get("last_quote", {})
+            bid = quote.get("bid_price")
+            ask = quote.get("ask_price")
+            mid = item.get("day") or {}
+            mid_price = mid.get("mid")
+            if mid_price is None and bid is not None and ask is not None:
+                mid_price = (bid + ask) / 2
+            ticker_symbol = option_data.get("ticker", "")
+            if not ticker_symbol:
+                continue
+            option_type = OptionType.CALL if option_data.get("contract_type") == "call" else OptionType.PUT
+            expiry_str = option_data.get("expiration_date") or option_data.get("expiration")
+            if not expiry_str:
+                continue
+            expiry = datetime.fromisoformat(expiry_str)
+            contracts.append(
+                OptionContract(
+                    ticker=ticker_symbol.split(":")[0],
+                    expiry=expiry,
+                    strike=float(option_data.get("strike_price") or 0.0),
+                    option_type=option_type,
+                    bid=_to_float(bid),
+                    ask=_to_float(ask),
+                    mid=_to_float(mid_price),
+                    mark_iv=_to_float(greeks.get("iv")),
+                    delta=_to_float(greeks.get("delta")),
+                    gamma=_to_float(greeks.get("gamma")),
+                    vega=_to_float(greeks.get("vega")),
+                    theta=_to_float(greeks.get("theta")),
+                    volume=_to_float(item.get("volume")),
+                    open_interest=_to_float(option_data.get("open_interest")),
+                    underlying_price=_to_float(item.get("underlying_asset", {}).get("price")),
+                    provider_payload=item,
+                )
+            )
+            if max_contracts and len(contracts) >= max_contracts:
+                break
+        return contracts
+
+    def get_underlying_ohlc(self, ticker: str, lookback_days: int) -> pd.DataFrame:
+        end = datetime.utcnow()
+        start = end - timedelta(days=lookback_days * 2)
+        path = f"/v2/aggs/ticker/{ticker.upper()}/range/1/day/{start:%Y-%m-%d}/{end:%Y-%m-%d}"
+        data = self._request("GET", path)
+        results = data.get("results", [])
+        if not results:
+            return pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+        frame = pd.DataFrame(results)
+        frame["t"] = pd.to_datetime(frame["t"], unit="ms")
+        frame = frame.set_index("t")
+        frame = frame.rename(
+            columns={
+                "o": "open",
+                "h": "high",
+                "l": "low",
+                "c": "close",
+                "v": "volume",
+            }
+        )
+        return frame[["open", "high", "low", "close", "volume"]]
+
+    def get_iv_history(self, ticker: str, lookback_days: int) -> pd.Series | None:
+        params = {
+            "ticker": ticker.upper(),
+            "timespan": "day",
+            "adjusted": "true",
+            "window": 1,
+            "limit": lookback_days,
+        }
+        data = self._request("GET", "/v1/indicators/iv", params=params)
+        results = data.get("results", {})
+        values = results.get("values") or []
+        if not values:
+            return None
+        frame = pd.DataFrame(values)
+        frame["timestamp"] = pd.to_datetime(frame["timestamp"], unit="ms")
+        frame = frame.set_index("timestamp")
+        if "value" in frame.columns:
+            series = frame["value"].astype(float)
+        elif "iv" in frame.columns:
+            series = frame["iv"].astype(float)
+        else:
+            return None
+        return series
+
+    def get_theo_price(self, option: OptionContract) -> float | None:
+        details = option.provider_payload.get("details") if option.provider_payload else None
+        if details and "theoretical_price" in details:
+            return _to_float(details.get("theoretical_price"))
+        return None
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+
+__all__ = ["PolygonProvider"]

--- a/opti_screener/data_providers/tradier.py
+++ b/opti_screener/data_providers/tradier.py
@@ -1,0 +1,174 @@
+"""Tradier REST data provider."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta
+from typing import Any
+
+import pandas as pd
+import requests
+
+from ..models import OptionContract, OptionType
+from ..utils import LOGGER, require_env
+from .base import BaseProvider
+
+
+class TradierProvider(BaseProvider):
+    """Data provider that retrieves information from Tradier."""
+
+    name = "tradier"
+    BASE_URL = "https://api.tradier.com"
+
+    def __init__(self, session: requests.Session | None = None) -> None:
+        self.api_key = require_env("TRADIER_API_KEY")
+        self.session = session or requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/json",
+        })
+
+    def _request(self, method: str, path: str, params: dict[str, Any] | None = None) -> Any:
+        url = f"{self.BASE_URL}{path}"
+        params = params or {}
+        backoff = 1.0
+        for attempt in range(5):
+            response = self.session.request(method, url, params=params, timeout=30)
+            if response.status_code == 200:
+                return response.json()
+            if response.status_code in {429, 500, 502, 503, 504}:
+                LOGGER.warning(
+                    "Tradier request %s failed with status %s; retrying in %.1fs",
+                    path,
+                    response.status_code,
+                    backoff,
+                )
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            try:
+                payload = response.json()
+            except Exception:  # pragma: no cover
+                response.raise_for_status()
+            message = payload.get("fault", {}).get("faultstring") or payload.get("message") or str(payload)
+            raise RuntimeError(f"Tradier API error ({response.status_code}): {message}")
+        raise RuntimeError(f"Tradier API request {path} failed after retries")
+
+    def get_chain(
+        self, ticker: str, asof: datetime | None = None, max_contracts: int | None = None
+    ) -> list[OptionContract]:
+        params = {
+            "symbol": ticker.upper(),
+            "greeks": "true",
+        }
+        if asof is not None:
+            params["expiration"] = asof.strftime("%Y-%m-%d")
+        data = self._request("GET", "/v1/markets/options/chains", params=params)
+        options = data.get("options", {}).get("option", [])
+        if isinstance(options, dict):
+            options = [options]
+        contracts: list[OptionContract] = []
+        for item in options:
+            option_type = OptionType.CALL if item.get("option_type") == "call" else OptionType.PUT
+            expiry_str = item.get("expiration_date") or item.get("expiration")
+            if not expiry_str:
+                continue
+            expiry = datetime.fromisoformat(expiry_str)
+            greeks = item.get("greeks") or {}
+            bid = _to_float(item.get("bid"))
+            ask = _to_float(item.get("ask"))
+            mid = _mid_from_quotes(bid, ask)
+            contracts.append(
+                OptionContract(
+                    ticker=ticker.upper(),
+                    expiry=expiry,
+                    strike=float(item.get("strike") or 0.0),
+                    option_type=option_type,
+                    bid=bid,
+                    ask=ask,
+                    mid=mid,
+                    mark_iv=_to_float(greeks.get("mid_iv")) or _to_float(item.get("implied_volatility")),
+                    delta=_to_float(greeks.get("delta")),
+                    gamma=_to_float(greeks.get("gamma")),
+                    vega=_to_float(greeks.get("vega")),
+                    theta=_to_float(greeks.get("theta")),
+                    volume=_to_float(item.get("volume")),
+                    open_interest=_to_float(item.get("open_interest")),
+                    underlying_price=_to_float(item.get("underlying_price")),
+                    provider_payload=item,
+                )
+            )
+            if max_contracts and len(contracts) >= max_contracts:
+                break
+        return contracts
+
+    def get_underlying_ohlc(self, ticker: str, lookback_days: int) -> pd.DataFrame:
+        end = datetime.utcnow()
+        start = end - timedelta(days=lookback_days * 2)
+        params = {
+            "symbol": ticker.upper(),
+            "interval": "daily",
+            "start": start.strftime("%Y-%m-%d"),
+            "end": end.strftime("%Y-%m-%d"),
+        }
+        data = self._request("GET", "/v1/markets/history", params=params)
+        history = data.get("history", {}).get("day", [])
+        if isinstance(history, dict):
+            history = [history]
+        if not history:
+            return pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+        frame = pd.DataFrame(history)
+        frame["date"] = pd.to_datetime(frame["date"])
+        frame = frame.set_index("date")
+        frame = frame.rename(
+            columns={
+                "open": "open",
+                "high": "high",
+                "low": "low",
+                "close": "close",
+                "volume": "volume",
+            }
+        )
+        return frame[["open", "high", "low", "close", "volume"]].astype(float)
+
+    def get_iv_history(self, ticker: str, lookback_days: int) -> pd.Series | None:
+        params = {
+            "symbol": ticker.upper(),
+            "interval": "daily",
+        }
+        data = self._request("GET", "/v1/markets/options/iv", params=params)
+        series = data.get("implied_volatility", {}).get("data")
+        if not series:
+            return None
+        frame = pd.DataFrame(series)
+        frame["date"] = pd.to_datetime(frame["date"])
+        frame = frame.set_index("date")
+        frame = frame.sort_index().tail(lookback_days)
+        if "iv30" in frame.columns:
+            return frame["iv30"].astype(float)
+        if "value" in frame.columns:
+            return frame["value"].astype(float)
+        return None
+
+    def get_theo_price(self, option: OptionContract) -> float | None:
+        if option.provider_payload and "theoretical" in option.provider_payload:
+            return _to_float(option.provider_payload.get("theoretical"))
+        return None
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):  # pragma: no cover
+        return None
+
+
+def _mid_from_quotes(bid: float | None, ask: float | None) -> float | None:
+    if bid is not None and ask is not None:
+        return (bid + ask) / 2
+    return bid or ask
+
+
+__all__ = ["TradierProvider"]

--- a/opti_screener/models.py
+++ b/opti_screener/models.py
@@ -1,0 +1,63 @@
+"""Domain models for the opti_screener package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+
+class OptionType(str, Enum):
+    """Enumerates supported option contract types."""
+
+    CALL = "call"
+    PUT = "put"
+
+    @property
+    def sign(self) -> int:
+        """Return +1 for calls and -1 for puts."""
+
+        return 1 if self is OptionType.CALL else -1
+
+
+@dataclass(slots=True)
+class OptionContract:
+    """Represents an option contract and associated market data."""
+
+    ticker: str
+    expiry: datetime
+    strike: float
+    option_type: OptionType
+    bid: float | None
+    ask: float | None
+    mid: float | None
+    mark_iv: float | None
+    delta: float | None
+    gamma: float | None
+    vega: float | None
+    theta: float | None
+    volume: float | None
+    open_interest: float | None
+    underlying_price: float | None
+    provider_payload: dict[str, Any] = field(default_factory=dict)
+
+    def copy_with(self, **updates: Any) -> "OptionContract":
+        """Return a shallow copy with the given fields updated."""
+
+        data = self.__dict__.copy()
+        data.update(updates)
+        return OptionContract(**data)
+
+    @property
+    def premium(self) -> float | None:
+        """Return the tradable premium using the mid price if available."""
+
+        if self.mid is not None:
+            return self.mid
+        if self.bid is not None and self.ask is not None:
+            return (self.bid + self.ask) / 2
+        return self.bid or self.ask
+
+
+__all__ = ["OptionContract", "OptionType"]

--- a/opti_screener/ranking.py
+++ b/opti_screener/ranking.py
@@ -1,0 +1,86 @@
+"""Scoring and ranking logic for option screening."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from .analytics import apply_scoring
+
+
+@dataclass(slots=True)
+class FilterConfig:
+    """Filter configuration used to prune option chains."""
+
+    min_dte: int = 30
+    max_dte: int = 90
+    min_delta: float = 0.25
+    max_delta: float = 0.40
+    min_put_delta: float = -0.40
+    max_put_delta: float = -0.25
+    max_spread_pct: float = 0.10
+    max_spread_absolute: float = 0.10
+    min_oi: float = 300
+    min_volume: float = 1
+    max_premium: float | None = None
+    strategy: str = "both"  # calls, puts, both
+
+
+DEFAULT_WEIGHTS = {
+    "w1": 1.0,
+    "w2": 0.5,
+    "w3": 0.5,
+    "w4": 1.0,
+    "w5": 1.0,
+    "w6": 1.0,
+    "w7": 1.0,
+}
+
+
+def apply_filters(df: pd.DataFrame, config: FilterConfig) -> pd.DataFrame:
+    """Filter the dataframe according to the provided configuration."""
+
+    filtered = df.copy()
+    filtered = filtered[(filtered["dte"] >= config.min_dte) & (filtered["dte"] <= config.max_dte)]
+    if config.strategy.lower() == "calls":
+        filtered = filtered[filtered["type"].str.lower() == "call"]
+    elif config.strategy.lower() == "puts":
+        filtered = filtered[filtered["type"].str.lower() == "put"]
+    # Delta filters
+    delta_series = pd.to_numeric(filtered["delta"], errors="coerce")
+    filtered = filtered.assign(delta_numeric=delta_series)
+    is_call = filtered["type"].str.lower() == "call"
+    is_put = filtered["type"].str.lower() == "put"
+    call_mask = is_call & filtered["delta_numeric"].between(
+        config.min_delta, config.max_delta, inclusive="both"
+    )
+    put_mask = is_put & filtered["delta_numeric"].between(
+        config.max_put_delta, config.min_put_delta, inclusive="both"
+    )
+    filtered = filtered[call_mask | put_mask]
+    # Liquidity filters
+    filtered = filtered[
+        (filtered["open_interest"].fillna(0) >= config.min_oi)
+        & (filtered["volume"].fillna(0) >= config.min_volume)
+    ]
+    spread_pct_ok = filtered["spread_pct"].fillna(1.0) <= config.max_spread_pct
+    spread_abs_ok = (
+        filtered["spread"].fillna(config.max_spread_absolute)
+        <= config.max_spread_absolute
+    ) | (filtered["mid"].fillna(0) >= 2)
+    filtered = filtered[spread_pct_ok | spread_abs_ok]
+    if config.max_premium is not None:
+        filtered = filtered[filtered["mid"].fillna(config.max_premium + 1) <= config.max_premium]
+    return filtered.drop(columns=["delta_numeric"])
+
+
+def rank_contracts(df: pd.DataFrame, weights: dict[str, float]) -> pd.DataFrame:
+    """Apply scoring and return a ranked dataframe sorted by total score."""
+
+    scored = apply_scoring(df, weights)
+    scored = scored.sort_values("TotalScore", ascending=False)
+    return scored.reset_index(drop=True)
+
+
+__all__ = ["FilterConfig", "DEFAULT_WEIGHTS", "apply_filters", "rank_contracts"]

--- a/opti_screener/utils.py
+++ b/opti_screener/utils.py
@@ -1,0 +1,140 @@
+"""Utility helpers for opti_screener."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+LOGGER = logging.getLogger("opti_screener")
+
+
+def setup_logging(verbose: bool = False) -> None:
+    """Configure logging for the CLI."""
+
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def parse_list(value: str | None) -> list[str]:
+    """Parse a comma-separated list string into a list of stripped values."""
+
+    if not value:
+        return []
+    return [item.strip().upper() for item in value.split(",") if item.strip()]
+
+
+def parse_weights(weights: str | None, defaults: dict[str, float]) -> dict[str, float]:
+    """Parse a weight override string into a dictionary."""
+
+    result = defaults.copy()
+    if not weights:
+        return result
+    for part in weights.split(","):
+        if not part.strip():
+            continue
+        if "=" not in part:
+            raise ValueError(f"Invalid weight segment: {part!r}")
+        key, raw_value = (item.strip() for item in part.split("=", 1))
+        if key not in result:
+            raise KeyError(f"Unknown weight key {key!r}")
+        try:
+            result[key] = float(raw_value)
+        except ValueError as exc:
+            raise ValueError(f"Invalid numeric weight for {key!r}: {raw_value!r}") from exc
+    return result
+
+
+def clamp(value: float, minimum: float, maximum: float) -> float:
+    """Clamp *value* to the inclusive range [minimum, maximum]."""
+
+    return max(minimum, min(maximum, value))
+
+
+def safe_div(numerator: float | None, denominator: float | None) -> float | None:
+    """Safely divide two numbers returning ``None`` if not possible."""
+
+    if numerator is None or denominator in (None, 0):
+        return None
+    return numerator / denominator
+
+
+def ensure_directory(path: Path) -> None:
+    """Ensure that the parent directory of ``path`` exists."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def write_metadata(path: Path, metadata: dict[str, object]) -> None:
+    """Write metadata JSON next to ``path``."""
+
+    ensure_directory(path)
+    meta_path = path.with_suffix(path.suffix + ".meta.json")
+    with meta_path.open("w", encoding="utf-8") as file:
+        json.dump(metadata, file, indent=2, default=_json_default)
+
+
+def _json_default(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    if hasattr(value, "__dict__"):
+        return value.__dict__
+    if hasattr(value, "_asdict"):
+        return value._asdict()
+    if hasattr(value, "__slots__"):
+        return {slot: getattr(value, slot) for slot in value.__slots__}
+    if hasattr(value, "__iter__") and not isinstance(value, (str, bytes)):
+        return list(value)  # type: ignore[return-value]
+    return value
+
+
+def require_env(name: str) -> str:
+    """Return the environment variable ``name`` or raise a helpful error."""
+
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(
+            f"Environment variable {name} is required for the selected provider."
+        )
+    return value
+
+
+def daterange_days(start: datetime, end: datetime) -> int:
+    """Return the number of days between two dates."""
+
+    return (end.date() - start.date()).days
+
+
+def zscore(series: Iterable[float | None]) -> list[float | None]:
+    """Return z-score normalized values handling ``None`` entries."""
+
+    values = [value for value in series if value is not None]
+    if not values:
+        return [None for _ in series]
+    mean = sum(values) / len(values)
+    variance = sum((value - mean) ** 2 for value in values) / max(len(values) - 1, 1)
+    std = math.sqrt(variance)
+    if std == 0:
+        return [0.0 if value is not None else None for value in series]
+    return [((value - mean) / std) if value is not None else None for value in series]
+
+
+def asdict_sans_none(obj: object) -> dict[str, object]:
+    """Return a dictionary representation without ``None`` values."""
+
+    data = asdict(obj)
+    return {key: value for key, value in data.items() if value is not None}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+pandas>=2.0
+numpy>=1.24
+requests>=2.31
+python-dotenv>=1.0
+rich>=13.0
+typer[all]>=0.9
+pyyaml>=6.0
+pytest>=7.0
+black>=23.0
+ruff>=0.0.289

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from opti_screener.analytics import (
+    apply_scoring,
+    compute_contract_rows,
+    compute_historical_volatility,
+    expected_move_from_straddle,
+)
+from opti_screener.models import OptionContract, OptionType
+
+
+def make_contract(**kwargs):
+    defaults = dict(
+        ticker="TEST",
+        expiry=datetime.utcnow() + timedelta(days=45),
+        strike=100.0,
+        option_type=OptionType.CALL,
+        bid=5.0,
+        ask=6.0,
+        mid=5.5,
+        mark_iv=0.25,
+        delta=0.3,
+        gamma=0.05,
+        vega=0.1,
+        theta=-0.02,
+        volume=500,
+        open_interest=1000,
+        underlying_price=100.0,
+        provider_payload={},
+    )
+    defaults.update(kwargs)
+    return OptionContract(**defaults)
+
+
+def test_historical_volatility_matches_manual_calculation():
+    prices = pd.Series([100 * (1.01) ** i for i in range(0, 30)])
+    hv = compute_historical_volatility(prices, 20)
+    returns = prices.pct_change().dropna().iloc[-20:]
+    expected = np.sqrt(252) * returns.std(ddof=1)
+    assert hv == pytest.approx(expected)
+
+
+def test_expected_move_from_straddle():
+    expiry = datetime.utcnow() + timedelta(days=45)
+    call = make_contract(option_type=OptionType.CALL, expiry=expiry, strike=100, mid=5.0)
+    put = make_contract(option_type=OptionType.PUT, expiry=expiry, strike=100, mid=4.0)
+    data = expected_move_from_straddle([call, put], spot=100)
+    em_dollar, em_pct = data[expiry]
+    assert em_dollar == pytest.approx(9.0)
+    assert em_pct == pytest.approx(0.09)
+
+
+def test_apply_scoring_handles_missing_values():
+    expiry = datetime.utcnow() + timedelta(days=45)
+    contracts = [
+        make_contract(expiry=expiry, mid=10.0, mark_iv=0.3, volume=100, open_interest=2000),
+        make_contract(
+            option_type=OptionType.PUT,
+            expiry=expiry,
+            strike=95,
+            mid=8.0,
+            mark_iv=0.28,
+            volume=None,
+            open_interest=None,
+        ),
+    ]
+    expected_moves = {expiry: (10.0, 0.1)}
+    frame = compute_contract_rows(
+        contracts=contracts,
+        hv20=0.2,
+        hv60=0.25,
+        iv_history=pd.Series([0.2, 0.25, 0.3]),
+        asof=datetime.utcnow(),
+        expected_moves=expected_moves,
+        theo_prices={f"{c.ticker}-{c.expiry.isoformat()}-{c.option_type.value}-{c.strike:.2f}": None for c in contracts},
+    )
+    scored = apply_scoring(frame, {"w1": 1, "w2": 1, "w3": 1, "w4": 1, "w5": 1, "w6": 1, "w7": 1})
+    assert "TotalScore" in scored.columns
+    assert not scored["TotalScore"].isna().any()


### PR DESCRIPTION
## Summary
- implement the `opti_screener` Typer CLI with configurable filters, weight parsing, output handling, and provider fallback
- add analytics, ranking, and data-provider modules to compute HV/IV metrics, expected moves, and scoring for option chains
- document setup and usage in README and provide unit tests for volatility, expected move, and scoring helpers

## Testing
- pytest *(fails: missing third-party dependencies such as numpy are not installable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dae5b977b0832c9fd1498751b7c7d6